### PR TITLE
Schleife beim Ersetzen von Autorennamen umgedreht.

### DIFF
--- a/PicaSWB.js
+++ b/PicaSWB.js
@@ -109,10 +109,10 @@ function doExport() {
 			var creator = item.creators.shift();
 			if (creator.creatorType == "author") {
 				var content;
-				if (nachnameMapping[creator.lastName]) {
-					content = nachnameMapping[creator.lastName];
-				} else if (creator.firstName && nameMapping[creator.lastName + ", " + creator.firstName]) {
+				if (creator.firstName && nameMapping[creator.lastName + ", " + creator.firstName]) {
 					content = nameMapping[creator.lastName + ", " + creator.firstName];
+				} else if (nachnameMapping[creator.lastName]) {
+					content = nachnameMapping[creator.lastName];
 				} else {
 					content = creator.lastName + (creator.firstName ? ", " + creator.firstName : "");
 				}


### PR DESCRIPTION
1. zuerst die Bedingung: wenn Nachname und Vorname exakt übereinstimmen, dann durch entsprechende PPN ersetzen. 
2. Dann: wenn nicht, dann nach den Nachnamen schauen und dann durch entsprechende PPN ersetzen. 
   Grund: erst im zweiten Schritt soll nach der Liste von Nachnamen nachgeschaut werden, da häufiger abgekürzte Form von Vornamen vorkommen.
