### PR TITLE
Improve JSHint reporting for npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Erweiterung von Zotero für die Katalogisierung in Bibliotheken",
   "main": "PicaSWB.js",
   "scripts": {
-    "test": "for f in BIBFRAME.js MARC21XML.js PicaSWB.js;do printf $f;printf '\n';sed '1,/^}/d' $f|jshint -;done"
+    "test": "for f in *.js;do sed '1,/^}/d' $f|jshint --filename=$f - && echo \"$f OK\" || err=1;done;exit $err"
   },
   "devDependencies": {
     "jshint": "^2.9.1"


### PR DESCRIPTION
- Show "filename.js OK" if all is well
- Show errors if any
- Fail 'npm test' if any check failed
