### PR TITLE
July Update

### DIFF
--- a/Wikidata QuickStatements.js
+++ b/Wikidata QuickStatements.js
@@ -139,6 +139,7 @@ function doExport() {
 			}
 		}
 		
+		var index = 1;
 		for (var i=0; i<item.creators.length; i++) {
 			var creatorValue = item.creators[i].lastName;
 			var creatorType = item.creators[i].creatorType;
@@ -146,7 +147,8 @@ function doExport() {
 				creatorValue = item.creators[i].firstName + ' ' + creatorValue;
 			}
 			if (creatorType=="author") {
-				Zotero.write('LAST	P2093	"' + creatorValue + '"\n');
+				Zotero.write('LAST	P2093	"' + creatorValue + '"	P1545	"' + index+ '"\n');
+				index++;
 			}
 			//other creatorTypes are ignored, because they would need to point an item, rather than just writing the string value
 		}

--- a/Wikidata QuickStatements.js
+++ b/Wikidata QuickStatements.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 2,
 	"browserSupport": "gcs",
-	"lastUpdated": "2017-06-22 07:00:00"
+	"lastUpdated": "2017-07-15 20:00:00"
 }
 
 
@@ -131,6 +131,20 @@ function doExport() {
 			Zotero.write('LAST	P31	' + typeMapping[itemType] + '\n');
 		}
 		Zotero.write('LAST	Len	"' + item.title + '"\n');
+		
+		var description = itemType.replace(/([A-Z])/, function(match, firstLetter) {
+			return ' ' + firstLetter.toLowerCase();
+		});
+		if (item.publicationTitle) {
+			description = description + ' from \'' + item.publicationTitle + '\'';
+		}
+		if (item.date) {
+			var year = ZU.strToDate(item.date).year;
+			if (year) {
+				description = description + ' published in ' + year;
+			}
+		}
+		Zotero.write('LAST	Den	"' + description + '"\n');
 		
 		for (var pnumber in propertyMapping) {
 			var zfield = propertyMapping[pnumber];

--- a/Wikidata QuickStatements.js
+++ b/Wikidata QuickStatements.js
@@ -135,7 +135,7 @@ function doExport() {
 		var description = itemType.replace(/([A-Z])/, function(match, firstLetter) {
 			return ' ' + firstLetter.toLowerCase();
 		});
-		if (item.publicationTitle) {
+		if (item.publicationTitle && (itemType=="journalArticle" || itemType=="magazineArticle" || itemType=="newspaperArticle")) {
 			description = description + ' from \'' + item.publicationTitle + '\'';
 		}
 		if (item.date) {


### PR DESCRIPTION
These adds the series ordinal for the authors and a description as discussed in the corresponding issues.

Some testing and feedback would be fine now, @pigsonthewing, @nichtich.

For example the description can become quite detailed now, e.g. `LAST	Den	"conference paper from 'Ninth International Conference on Document Analysis and Recognition (ICDAR 2007)' published in 2007"`, but maybe this is still fine. The numbers are always added now, also when there is only one author. What do you think?