### PR TITLE
[PicaGBV] Heftzählung

### DIFF
--- a/PicaGBV.js
+++ b/PicaGBV.js
@@ -309,12 +309,12 @@ function doExport() {
 		//Angaben zu illustrierendem Inhalt, muss händisch weiter gefüllt werden
 		writeLine("4061", "");
 		
-		//4070 $v Bandzählung $j Jahr $h Heftnummer $p Seitenzahl
+		//4070 $v Bandzählung $j Jahr $a Heftnummer $p Seitenzahl
 		if (item.itemType == "journalArticle" || item.itemType == "magazineArticle" || item.itemType == "bookSection") {
 			var volumeyearissuepage = "";
 			if (item.volume) { volumeyearissuepage += "$v" + item.volume; }
 			if (date.year !== undefined) { volumeyearissuepage +=  "$j" + date.year; }
-			if (item.issue) { volumeyearissuepage += "$h" + item.issue; }
+			if (item.issue) { volumeyearissuepage += "$a" + item.issue; }
 			if (item.pages) { volumeyearissuepage += "$p" + item.pages; }
 			
 			writeLine("4070", volumeyearissuepage);


### PR DESCRIPTION
Heftzählung in 4070 angepasst, ist im GBV $a statt $h im SWB (s. http://swbtools.bsz-bw.de/cgi-bin/help.pl?cmd=kat&val=4070&regelwerk=RDA&verbund=GBV)