### PR TITLE
Abstract: Select field by length

### DIFF
--- a/PicaGBV.js
+++ b/PicaGBV.js
@@ -12,7 +12,7 @@
 	"displayOptions": {
 		"Gedruckte Ressource": false
 	},
-	"lastUpdated": "2018-03-18 15:25:00"
+	"lastUpdated": "2018-08-25 13:00:00"
 }
 
 
@@ -346,11 +346,12 @@ function doExport() {
 		writeLine("4201", "");
 		
 		//Inhaltliche Zusammenfassung --> 4207/4209
-		if (item.abstractNote && item.abstractNote.length <= 600) {
-			writeLine("4207", item.abstractNote);
-		}
-		if (item.abstractNote && item.abstractNote.length > 600){
-			writeLine("4209", item.abstractNote);
+		if (item.abstractNote && exportAbstract) {
+			if (item.abstractNote.length <= 600) {
+				writeLine("4207", item.abstractNote);
+			} else {
+				writeLine("4209", item.abstractNote);
+			}
 		}
 		
 		//item.publicationTitle --> 4241 Beziehungen zur größeren Einheit 

--- a/PicaGBV.js
+++ b/PicaGBV.js
@@ -345,9 +345,12 @@ function doExport() {
 		//Sonstige Anmerkungen (manuell eintragen) --> 4201
 		writeLine("4201", "");
 		
-		//Inhaltliche Zusammenfassung -->4207
-		if (item.abstractNote && exportAbstract) {
+		//Inhaltliche Zusammenfassung --> 4207/4209
+		if (item.abstractNote && item.abstractNote.length <= 600) {
 			writeLine("4207", item.abstractNote);
+		}
+		if (item.abstractNote && item.abstractNote.length > 600){
+			writeLine("4209", item.abstractNote);
 		}
 		
 		//item.publicationTitle --> 4241 Beziehungen zur größeren Einheit 


### PR DESCRIPTION
Im GBV Unterscheidung zwischen Abstract <= 600 Zeichen (4207) und Abstract > 600 Zeichen (4209); Zeichen werden nun gezählt und das entsprechende Feld belegt. Danke @zuphilip