### PR TITLE
WQS: Skip items with a QID in the extra field

### DIFF
--- a/Wikidata QuickStatements.js
+++ b/Wikidata QuickStatements.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 2,
 	"browserSupport": "gcs",
-	"lastUpdated": "2019-12-29 15:00:00"
+	"lastUpdated": "2019-12-29 21:00:00"
 }
 
 
@@ -268,6 +268,10 @@ function zoteroItemToQuickStatements(item) {
 function doExport() {
 	var item;
 	while ((item = Zotero.nextItem())) {
+		// skipping items with a QID saved in extra
+		if (item.extra && item.extra.match(/^QID: /m)) continue;
+
+		// write the statements
 		Zotero.write(zoteroItemToQuickStatements(item));
 	}
 }


### PR DESCRIPTION
The Zotero Script https://gist.github.com/zuphilip/aa9f59271fcb0807fb20c7d0110d26e4
can lookup the items in Wikidata first and add a QID in the extra field.
When the export script is then afterwards performed, then the already existing
items in Wikidata will be skipped.