### PR TITLE
Be more flexible about QID in extra field

### DIFF
--- a/Wikidata QuickStatements.js
+++ b/Wikidata QuickStatements.js
@@ -298,7 +298,7 @@ function doExport() {
 	var item;
 	while ((item = Zotero.nextItem())) {
 		// skipping items with a QID saved in extra
-		if (item.extra && item.extra.match(/^QID: /m)) continue;
+		if (item.extra && item.extra.match(/^QID:/im)) continue;
 
 		// write the statements
 		Zotero.write(zoteroItemToQuickStatements(item));


### PR DESCRIPTION
The QuickStatements export translator intentionally doesn't output anything if the item already has a QID in the extra field. However, it is strict about the format how it has to be specified: "^QID: " (uppercase "QID" at the beginning of the line, followed by ":", followed by space".

Although this seems to be the format [suggested](https://www.zotero.org/support/kb/item_types_and_fields#additional_item_types_and_fields) in the Zotero documentation, and it has been [said](https://www.zotero.org/support/kb/item_types_and_fields#additional_item_types_and_fields) that it is Zotero's main developer preferred way, they don't seem to be strict about it.

Do you think we could make it more flexible? That is, case-insensitive and with or without a space after the colon?

BTW, apart from this translator and the Wikicite [plugin](https://github.com/diegodlh/zotero-wikicite/) I'm developing, do you know of any other plugin/translator that expects the QID to be in the extra field?  The Wikidata web translator currently doesn't, as proposed that it does [here](https://github.com/zotero/translators/pull/2362).